### PR TITLE
Replace `~` with `true` to use refname

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,7 +1,7 @@
 ---
 name: fawkes
 title: Fawkes
-version: ~
+version: true
 prerelease: true
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
The `~` was incorrect, and sets fawkes as unversioned. We want `true` to find the version from the refname instead for tags to work.

Also removes pre-release, it will inherently set if we don't use X.Y.Z version string.