### PR TITLE
Remove comment about isolated network

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+### Summary and Scope
+
+<!--- Pick one below and delete the rest -->
+<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->
+
+- Fixes:
+- Requires:
+- Relates to:
+
+#### Issue Type
+
+<!--- Delete un-needed bullets -->
+
+- Bugfix Pull Request
+- Docs Pull Request
+- RFE Pull Request
+
+<!--- words; describe what this change is and what it is for. -->
+
+### Prerequisites
+
+<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
+<!--- unchecked checkbox: [ ] -->
+<!--- checked checkbox: [x] -->
+<!--- invalid checkbox: [] -->
+
+- [ ] I have included documentation in my PR (or it is not required)
+- [ ] I tested this on internal system (if yes, please include results or a description of the test)
+- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
+ 
+### Idempotency
+ 
+<!--- describe testing done to verify code changes behave in an idempotent manner -->
+ 
+### Risks and Mitigations
+ 
+<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
+<!--- Example:
+
+This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
+is resolved and the overall risk of fatal failures is reduced.
+
+-->

--- a/modules/installation/pages/management-vm.adoc
+++ b/modules/installation/pages/management-vm.adoc
@@ -55,7 +55,6 @@ virsh vol-upload --pool management-pool management-vm.qcow2 /vms/images/manageme
 ----
 . Set up the local network to enable the management VM to orchestrate the initial hypervisor host
 +
-// FIXME: This is not fully implemented yet, and serves as scaffolding. At this time, the network has no connectivity.
 +
 [source,bash]
 ----
@@ -83,7 +82,17 @@ virsh create /srv/cray/management-vm/domain.xml
 ----
 . View the VM's console
 +
+NOTE: Leave the console by pressing the escape character `^]` (kbd:[CTRL] + kbd:[]]).
++
 [source,bash]
 ----
 virsh console management-vm
+----
+. Once the node is up and cloud-init has printed a message indicating it has finished, open a new window and SSH to the
+management-vm from the hypervisor node.
+// TODO: Change to SSH externally once we are happy with how the site-link is set up.
++
+[source,bash]
+----
+ssh -i ~/.ssh/<ssh-key> root@192.168.0.2
 ----


### PR DESCRIPTION
The isolated network is fixed in:
- https://github.com/Cray-HPE/metal-provision/pull/353
- https://github.com/Cray-HPE/metal-provision/pull/354

The commend regarding it's lack of function can be removed, and an SSH command can be added (mainly for verification purposes at this point).
