### PR TITLE
`inventory.yaml` is now nested

### DIFF
--- a/modules/installation/pages/3-management/1-management-vm.adoc
+++ b/modules/installation/pages/3-management/1-management-vm.adoc
@@ -79,7 +79,7 @@ NEXUS_URL=http://localhost:8081/nexus ./upload.sh
 +
 [source,bash]
 ----
-/opt/cray/ansible/bin/activate/ansible-playbook /srv/cray/metal-provision/bootserver.yml
+/opt/cray/ansible/bin/ansible-playbook /srv/cray/metal-provision/bootserver.yml
 ----
 +
 [TIP]

--- a/modules/installation/pages/4-cluster-deployment/2-node-deployment.adoc
+++ b/modules/installation/pages/4-cluster-deployment/2-node-deployment.adoc
@@ -82,7 +82,7 @@ Provision the hypervisor nodes.
 +
 [source,bash]
 ----
-/opt/cray/ansible/bin/activate/ansible-playbook \
+/opt/cray/ansible/bin/ansible-playbook \
     -i /etc/ansible/inventory \
     /srv/cray/metal-provision/hypervisor.yml
 ----

--- a/modules/installation/pages/4-cluster-deployment/3-kubernetes-vm.adoc
+++ b/modules/installation/pages/4-cluster-deployment/3-kubernetes-vm.adoc
@@ -35,14 +35,14 @@ ssh-keygen -q -t ed25519 -f ~/.ssh/id_ed25519_vm -N ''
 +
 [source,bash]
 ----
-yq eval -i '.node_defaults.ssh_keys += ["'"$(cat ~/.ssh/id_ed25519_vm.pub)"'"]' /srv/cray/terraform/prod/inventory.yaml
+yq eval -i '.node_defaults.ssh_keys += ["'"$(cat ~/.ssh/id_ed25519_vm.pub)"'"]' /srv/cray/terraform/prod/inventory/inventory.yaml
 ----
 . Update the `base_volume.name`
 +
 [source,bash]
 ----
 IMAGE_ID=6.1.30
-yq eval -i '.node_defaults.base_volume.name = .node_defaults.base_volume.name + "-'"${IMAGE_ID}"'"' /srv/cray/terraform/prod/inventory.yaml
+yq eval -i '.node_defaults.base_volume.name = .node_defaults.base_volume.name + "-'"${IMAGE_ID}"'"' /srv/cray/terraform/prod/inventory/inventory.yaml
 ----
 // TODO: AUTOMATE ENDS HERE
 . Review the plan for terraform


### PR DESCRIPTION
`inventory.yaml` is now nested in a subdirectory called `inventory/`.

This is true as of v1.2.0, which is currently included in our management-VM images.