### PR TITLE
Fix typo in URL

### DIFF
--- a/modules/installation/pages/2-pre-installation/1-usb-creation.adoc
+++ b/modules/installation/pages/2-pre-installation/1-usb-creation.adoc
@@ -53,7 +53,7 @@ NOTE: At this time, Fawkes is still in a pre-release state and the stable stream
 [source,bash]
 ----
 STREAM=unstable
-RELEASE="$(curl -u "${ARTIFACTORY_USER}":"${ARTIFACTORY_TOKEN}" "https://artifactory.algol60.net/artifactoy/api/search/latestVersion?g=${STREAM}&a=fawkes")"
+RELEASE="$(curl -u "${ARTIFACTORY_USER}":"${ARTIFACTORY_TOKEN}" "https://artifactory.algol60.net/artifactory/api/search/latestVersion?g=${STREAM}&a=fawkes")"
 ----
 . Download the tarball
 +


### PR DESCRIPTION
Typo causes URL to return a 404 error.
