### PR TITLE
belanaEtcher does not support native arm64

### DIFF
--- a/modules/installation/pages/2-pre-installation/1-usb-creation.adoc
+++ b/modules/installation/pages/2-pre-installation/1-usb-creation.adoc
@@ -185,7 +185,7 @@ CAUTION: The MacOS and Windows method will not enable persistence on the drive.
 
 This guide suggests the following third-party tools for USB creation.
 
-- link:https://etcher.balena.io/[belanaEtcher]
+- link:https://etcher.balena.io/[belanaEtcher] (`x86_64` only, no `arm64` support)
 
 ==== Steps
 


### PR DESCRIPTION
belanaEtcher does not offer an arm64 distributable. There are reports online that it runs nicely under emulation.

For now, note that arm64 support isn't available.
